### PR TITLE
Update Node.js

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
`browser-actions/setup-chrome` uses Node.js 12.
However, it is already EOL.
Therefore, I update it to 16 (Active LTS).

For your information: https://github.com/nodejs/Release