### PR TITLE
CI: Test current version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,9 +106,9 @@ jobs:
           git commit --message "Release for ${GITHUB_SHA}"
           git push origin latest
 
-  test-latest:
+  test:
     runs-on: ubuntu-latest
     needs: [deploy]
     steps:
-      - uses: browser-actions/setup-chrome@latest
+      - uses: ./
       - run: chrome --version


### PR DESCRIPTION
CI `test-latest` tests the latest version in GitHub Marketplace.
However, this CI should test current commit.
Therefore, I change it to test current commit.