### PR TITLE
feat: Output version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ steps:
   - uses: browser-actions/setup-chrome@v1
     with:
       chrome-version: beta
-  - run: chrome --version
+    id: setup-chrome
+  - run: |
+      echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
+      chrome --version
 ```
 
 **Note that the installed binary depends on your installation spec.**

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,9 @@ inputs:
       The Google Chrome/Chromium version to install and use.
     default: latest
     required: false
-
+outputs:
+  chrome-version:
+    description: 'The installed Google Chrome/Chromium version. Useful when given a latest version.'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Set up your GitHub Actions workflow with a specific version of chromium",
   "main": "dist/index.js",
   "dependencies": {
-    "@actions/core": "^1.9.1",
+    "@actions/core": "^1.10.0",
+    "@actions/exec": "^1.1.1",
     "@actions/io": "^1.1.2",
     "@actions/tool-cache": "^1.7.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,11 @@ async function run(): Promise<void> {
 
     core.addPath(path.join(installDir));
 
-    const actualVersions = await testVersion(platform, binPath);
+    const actualVersion = await testVersion(platform, binPath);
 
-    core.info(`Successfully setup chromium version ${actualVersions}`);
+    core.info(`Successfully setup chromium version ${actualVersion}`);
+
+    core.setOutput("chrome-version", actualVersion);
   } catch (error) {
     if (hasErrorMessage(error)) {
       core.setFailed(error.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,15 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.6", "@actions/core@^1.9.1":
+"@actions/core@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.10.0.tgz#44551c3c71163949a2f06e94d9ca2157a0cfac4f"
+  integrity sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==
+  dependencies:
+    "@actions/http-client" "^2.0.1"
+    uuid "^8.3.2"
+
+"@actions/core@^1.2.6":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.9.1.tgz#97c0201b1f9856df4f7c3a375cdcdb0c2a2f750b"
   integrity sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==
@@ -14,6 +22,13 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.0.4.tgz#99d75310e62e59fc37d2ee6dcff6d4bffadd3a5d"
   integrity sha512-4DPChWow9yc9W3WqEbUj8Nr86xkpyE29ZzWjXucHItclLbEW6jr80Zx4nqv18QL6KK65+cifiQZXvnqgTV6oHw==
+  dependencies:
+    "@actions/io" "^1.0.1"
+
+"@actions/exec@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.1.tgz#2e43f28c54022537172819a7cf886c844221a611"
+  integrity sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==
   dependencies:
     "@actions/io" "^1.0.1"
 


### PR DESCRIPTION
Supports installed versions via `chrome-version` property on the action outputs.
This is useful for installing a latest version.

```yaml
steps:
  - id: setup-chrome
    uses: browser-actions/setup-chrome@v1
  - run: |
      echo Installed version: ${{ steps.setup-chrome.outputs.chrome-version }}
```