### PR TITLE
feat: support M1/M2 mac

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -43,6 +43,8 @@ export const getArch = (): Arch => {
       return Arch.I686;
     case "x64":
       return Arch.AMD64;
+    case "arm64":
+      return Arch.ARM64;
   }
   throw new Error(`Unsupported arch: ${arch}`);
 };


### PR DESCRIPTION
Close #376.  This change enables running on macOS with M1/M2 (Apple Silicon).