### PR TITLE
fix: Update nodejs version 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ outputs:
   chrome-path:
     description: 'The installed Google Chrome/Chromium path.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2, browser-actions/setup-chrome@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.