### PR TITLE
feat: support `macos-14` runner

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -103,6 +103,8 @@ const makeBasename = ({ os }: Platform): string => {
 const makePlatformPart = ({ os, arch }: Platform): string => {
   if (os === OS.DARWIN && arch === Arch.AMD64) {
     return "Mac";
+  } else if (os === OS.DARWIN && arch === Arch.ARM64) {
+    return "Mac_Arm";
   } else if (os === OS.LINUX && arch === Arch.I686) {
     return "Linux";
   } else if (os === OS.LINUX && arch === Arch.AMD64) {


### PR DESCRIPTION
Adds support for latest `macos-14` Github Actions runner.

Error thrown without this fix: https://github.com/AriPerkkio/vitest/actions/runs/7714987182/job/21028492448

> Setup chromium latest
> Attempting to download latest...
> Error: Unsupported platform "darwin" "arm64"


Example run with the fix: https://github.com/AriPerkkio/vitest/actions/runs/7715353944/job/21029718900

> Setup chromium latest
> Attempting to download latest...
> Acquiring 1253941 from https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac_Arm%2F1253941%2Fchrome-mac.zip?alt=media
> Installing chromium...
> /usr/bin/unzip -o -q /Users/runner/work/_temp/e33ca3d9-cbbe-4f9a-a9cd-e4aba4d72a0f
> Successfully Installed chromium to /Users/runner/hostedtoolcache/chromium/latest/arm64
> /Users/runner/hostedtoolcache/chromium/latest/arm64/Chromium.app/Contents/MacOS/Chromium --version
> Chromium [12](https://github.com/AriPerkkio/vitest/actions/runs/7715353944/job/21029718900#step:4:13)3.0.6272.0 
> Successfully setup chromium version 123.0.6272.0
