### PR TITLE
feat: Add `install-dependencies` parameter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,23 @@ jobs:
       - if: runner.os == 'Windows'
         run: |
           (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chrome-path }}").Source).VersionInfo.ProductVersion
+
+  test-container:
+    needs: [build]
+    runs-on: ubuntu-latest
+    container:
+      image: debian
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+      - name: Install action dependencies
+        run: apt-get update && apt-get install -y unzip
+
+      - name: Install Google Chrome
+        uses: ./
+        with:
+          chrome-version: 120
+        id: setup-chrome
+      - run: |
+          "${{ steps.setup-chrome.outputs.chrome-path }}" --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,12 @@ jobs:
         run: apt-get update && apt-get install -y unzip
         if: ${{ matrix.container == 'debian' || matrix.container == 'ubuntu' || matrix.container == 'linuxmintd/mint21-amd64' }}
 
+      - name: Install action dependencies
+        run: yum install --assumeyes unzip
+        if: ${{ matrix.container == 'redhat/ubi9' || matrix.container == 'oraclelinux:9' || matrix.container == 'fedora' }}
+      - name: Install action dependencies
+        run: zypper install --no-confirm unzip
+        if: ${{ matrix.container == 'opensuse/leap' || matrix.container == 'registry.suse.com/bci/bci-base:15.5' }}
       - name: Install Google Chrome
         uses: ./
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
         uses: ./
         with:
           chrome-version: 120
+          install-dependencies: true
         id: setup-chrome
       - run: |
           "${{ steps.setup-chrome.outputs.chrome-path }}" --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,14 +56,9 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - redhat/ubi9
-          - oraclelinux:9
           - fedora
           - debian
-          - ubuntu
-          - linuxmintd/mint21-amd64
           - opensuse/leap
-          - registry.suse.com/bci/bci-base:15.5
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,15 +52,27 @@ jobs:
 
   test-container:
     needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - redhat/ubi9
+          - oraclelinux:9
+          - fedora
+          - debian
+          - ubuntu
+          - linuxmintd/mint21-amd64
+          - opensuse/leap
+          - registry.suse.com/bci/bci-base:15.5
     runs-on: ubuntu-latest
-    container:
-      image: debian
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: dist
       - name: Install action dependencies
         run: apt-get update && apt-get install -y unzip
+        if: ${{ matrix.container == 'debian' || matrix.container == 'ubuntu' || matrix.container == 'linuxmintd/mint21-amd64' }}
 
       - name: Install Google Chrome
         uses: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Install action dependencies
         run: zypper install --no-confirm unzip
         if: ${{ matrix.container == 'opensuse/leap' || matrix.container == 'registry.suse.com/bci/bci-base:15.5' }}
+      # Override GITHUB_PATH by the current PATH to prevent the issue discussed in https://github.com/actions/runner/issues/3210
+      - run: echo "$PATH" >>"$GITHUB_PATH"
+        if: ${{ matrix.container == 'opensuse/leap' || matrix.container == 'registry.suse.com/bci/bci-base:15.5' }}
       - name: Install Google Chrome
         uses: ./
         with:

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -10,6 +10,10 @@ on:
         - ubuntu
         - windows
         - macos
+      container:
+        description: 'Container image to run test on'
+        required: false
+        type: string
       chrome-version:
         description: 'Chrome version to install'
         required: false
@@ -38,6 +42,7 @@ jobs:
   test:
     needs: [build]
     runs-on: ${{ inputs.os }}-latest
+    container: ${{ inputs.container }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ steps:
       chrome-version: 120
 ```
 
+If you use the self-hosted runner, your runner may not have the required dependencies on the system.
+You can install the dependencies by using the `install-dependencies` parameter.
+It installs the required dependencies for the Google Chrome/Chromium to run automatically.
+
+```yaml
+steps:
+  - uses: browser-actions/setup-chrome@v1
+    with:
+      chrome-version: 120
+      install-dependencies: true
+```
+
 ### Supported version formats
 
 The action supports the following version formats:
@@ -63,6 +75,8 @@ steps:
 
 - `chrome-version`: *(Optional)* The Google Chrome/Chromium version to be installed.
   Default: `latest`
+- `install-dependencies`: *(Optional)* Install the required dependencies for the Google Chrome/Chromium to run.
+  Default: `false`
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
       The Google Chrome/Chromium version to install and use.
     default: latest
     required: false
+  install-dependencies:
+    description: |-
+      Install dependent packages for Google Chrome/Chromium (Linux only).
+    default: false
 outputs:
   chrome-version:
     description: 'The installed Google Chrome/Chromium version. Useful when given a latest version.'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@actions/exec": "^1.1.1",
     "@actions/http-client": "^2.2.0",
     "@actions/io": "^1.1.3",
-    "@actions/tool-cache": "^2.0.1"
+    "@actions/tool-cache": "^2.0.1",
+    "actions-swing": "^0.0.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@actions/tool-cache':
     specifier: ^2.0.1
     version: 2.0.1
+  actions-swing:
+    specifier: ^0.0.5
+    version: 0.0.5(@actions/core@1.10.1)(@actions/exec@1.1.1)
 
 devDependencies:
   '@types/jest':
@@ -1110,6 +1113,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
+
+  /actions-swing@0.0.5(@actions/core@1.10.1)(@actions/exec@1.1.1):
+    resolution: {integrity: sha512-JnOnk09lhKLTnWJS28YX4c9Jl1jczyHxhRHtcxKrX6wcXukO2K/ZlRoHgcmv5ccNyISBIVJE6I/W31VcmrmFaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@actions/core': '>=1'
+      '@actions/exec': '>=1'
+    dependencies:
+      '@actions/core': 1.10.1
+      '@actions/exec': 1.1.1
+    dev: false
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,8 +1,8 @@
-import { pkg } from "actions-swing";
+import { pkg, runtime } from "actions-swing";
 import type { Platform } from "./platform";
 import * as core from "@actions/core";
 
-const DEPENDENT_PACKAGES = [
+const DEBIAN_BASED_DEPENDENT_PACKAGES = [
   "libglib2.0-0",
   "libgconf-2-4",
   "libatk1.0-0",
@@ -19,6 +19,39 @@ const DEPENDENT_PACKAGES = [
   "xdg-utils",
 ];
 
+const FEDORA_BASED_DEPENDENT_PACKAGES = [
+  "alsa-lib",
+  "atk",
+  "at-spi2-atk",
+  "cups-libs",
+  "libdrm",
+  "libXcomposite",
+  "libXdamage",
+  "libxkbcommon",
+  "libXrandr",
+  "mesa-libgbm",
+  "nss",
+  "pango",
+];
+
+const SUSE_BASED_DEPENDENT_PACKAGES = [
+  "libasound2",
+  "libatk-1_0-0",
+  "libatk-bridge-2_0-0",
+  "libcups2",
+  "libdbus-1-3",
+  "libdrm2",
+  "libgbm1",
+  "libgobject-2_0-0",
+  "libpango-1_0-0",
+  "libXcomposite1",
+  "libXdamage1",
+  "libXfixes3",
+  "libxkbcommon0",
+  "libXrandr2",
+  "mozilla-nss",
+];
+
 const installDependencies = async (platform: Platform): Promise<void> => {
   if (platform.os !== "linux") {
     core.warning(
@@ -27,7 +60,27 @@ const installDependencies = async (platform: Platform): Promise<void> => {
     return;
   }
 
-  await pkg.install(DEPENDENT_PACKAGES);
+  const packages = await (async () => {
+    const osReleaseId = await runtime.getOsReleaseId();
+    switch (osReleaseId) {
+      case "rhel":
+      case "centos":
+      case "ol":
+      case "fedora":
+        return FEDORA_BASED_DEPENDENT_PACKAGES;
+      case "debian":
+      case "ubuntu":
+      case "linuxmint":
+        return DEBIAN_BASED_DEPENDENT_PACKAGES;
+      case "opensuse":
+      case "opensuse-leap":
+      case "sles":
+        return SUSE_BASED_DEPENDENT_PACKAGES;
+    }
+    throw new Error(`Unsupported OS: ${osReleaseId}`);
+  })();
+
+  await pkg.install(packages);
 };
 
 export { installDependencies };

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,0 +1,33 @@
+import { pkg } from "actions-swing";
+import type { Platform } from "./platform";
+import * as core from "@actions/core";
+
+const DEPENDENT_PACKAGES = [
+  "libglib2.0-0",
+  "libgconf-2-4",
+  "libatk1.0-0",
+  "libatk-bridge2.0-0",
+  "libgdk-pixbuf2.0-0",
+  "libgtk-3-0",
+  "libgbm-dev",
+  "libnss3-dev",
+  "libxss-dev",
+  "libasound2",
+  "xvfb",
+  "fonts-liberation",
+  "libu2f-udev",
+  "xdg-utils",
+];
+
+const installDependencies = async (platform: Platform): Promise<void> => {
+  if (platform.os !== "linux") {
+    core.warning(
+      `install-dependencies is only supported on Linux, but current platform is ${platform.os}`,
+    );
+    return;
+  }
+
+  await pkg.install(DEPENDENT_PACKAGES);
+};
+
+export { installDependencies };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import * as exec from "@actions/exec";
 import * as installer from "./installer";
 import { getPlatform, Platform, OS } from "./platform";
 import path from "path";
+import { installDependencies } from "./dependencies";
 
 const hasErrorMessage = (e: unknown): e is { message: string | Error } => {
   return typeof e === "object" && e !== null && "message" in e;
@@ -47,6 +48,13 @@ async function run(): Promise<void> {
   try {
     const version = core.getInput("chrome-version") || "latest";
     const platform = getPlatform();
+    const flagInstallDependencies =
+      core.getInput("install-dependencies") === "true";
+
+    if (flagInstallDependencies) {
+      core.info(`Installing dependencies`);
+      await installDependencies(platform);
+    }
 
     core.info(`Setup chromium ${version}`);
 


### PR DESCRIPTION
A new parameter `install-dependencies` is added to the action. The action will install the dependencies if the parameter is set to `true` on the Linux. It would be useful when you use the action on the self-hosted runner and want to install the dependencies automatically. This feature works only on the Linux runner, otherwise, it will be ignored.

```yaml
steps:
  - uses: browser-actions/setup-chrome@v1
    with:
      chrome-version: 120
      install-dependencies: true
```

Close #372