### PR TITLE
chore: bump snapshot version in the test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        version: ["", 827102, 120, dev]
+        version: ["", 1295939, 120, dev]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ steps:
 The action supports the following version formats:
 
 - The latest snapshot `latest` (default).
-- Commit positions like `848897`.  You can find commit positions from [here][snapshots].
+- Commit positions like `1295939`.  You can find commit positions from [here][snapshots].
 - Google Chrome release channels: `stable`, `beta`, `dev` and `canary`
 - Specific versions: `119`, `120.0.6099`, `121.0.6100.0`.  The version are resolved by [Chrome for Testing][].
 


### PR DESCRIPTION
Fix failed tests on CI

https://github.com/browser-actions/setup-chrome/actions/runs/8924654501/job/24511479711
```
Setup chromium 827102
Attempting to download 827102...
Acquiring 827102 from https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Mac_Arm%2F827102%2Fchrome-mac.zip?alt=media
Error: Unexpected HTTP response: 404
```