### PR TITLE
fix: use cached dir on linux

### DIFF
--- a/src/channel_linux.ts
+++ b/src/channel_linux.ts
@@ -72,6 +72,6 @@ export class LinuxChannelInstaller implements Installer {
     const root = await cache.cacheDir(extdir, "chromium", version);
     core.info(`Successfully Installed chromium to ${root}`);
 
-    return { root: extdir, bin: "chrome" };
+    return { root, bin: "chrome" };
   }
 }


### PR DESCRIPTION
The setup-chrome had returned the temporary directory instead of tool-cache.

https://github.com/browser-actions/setup-chrome/actions/runs/8947188430/job/24578811012
```
Successfully Installed chromium to /opt/hostedtoolcache/setup-chrome/chromium/dev/x64
/tmp/chrome-oyMgK9/chrome --version
```
This Pull Request fix as returning installed tool-cache directory.