### PR TITLE
Install package with sudo for non-root users by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: 'build-test'
 on:
-  pull_request:
   push:
     branches-ignore:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,14 +50,14 @@ jobs:
         run: |
           (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chrome-path }}").Source).VersionInfo.ProductVersion
 
-  test-container:
+  test-install-dependencies:
     needs: [build]
     strategy:
       fail-fast: false
       matrix:
         container:
+          - ""
           - fedora
-          - debian
           - opensuse/leap
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
@@ -68,16 +68,17 @@ jobs:
       - name: Install action dependencies
         run: apt-get update && apt-get install -y unzip
         if: ${{ matrix.container == 'debian' || matrix.container == 'ubuntu' || matrix.container == 'linuxmintd/mint21-amd64' }}
-
       - name: Install action dependencies
         run: yum install --assumeyes unzip
         if: ${{ matrix.container == 'redhat/ubi9' || matrix.container == 'oraclelinux:9' || matrix.container == 'fedora' }}
       - name: Install action dependencies
         run: zypper install --no-confirm unzip
         if: ${{ matrix.container == 'opensuse/leap' || matrix.container == 'registry.suse.com/bci/bci-base:15.5' }}
+
       # Override GITHUB_PATH by the current PATH to prevent the issue discussed in https://github.com/actions/runner/issues/3210
       - run: echo "$PATH" >>"$GITHUB_PATH"
         if: ${{ matrix.container == 'opensuse/leap' || matrix.container == 'registry.suse.com/bci/bci-base:15.5' }}
+
       - name: Install Google Chrome
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: |-
       Install dependent packages for Google Chrome/Chromium (Linux only).
     default: false
+  no-sudo:
+    description: |-
+      Do not use sudo to install Google Chrome/Chromium (Linux only).
+    default: false
 outputs:
   chrome-version:
     description: 'The installed Google Chrome/Chromium version. Useful when given a latest version.'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@actions/http-client": "^2.2.1",
     "@actions/io": "^1.1.3",
     "@actions/tool-cache": "^2.0.1",
-    "actions-swing": "^0.0.5"
+    "actions-swing": "^0.0.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^2.0.1
     version: 2.0.1
   actions-swing:
-    specifier: ^0.0.5
-    version: 0.0.5(@actions/core@1.10.1)(@actions/exec@1.1.1)
+    specifier: ^0.0.6
+    version: 0.0.6(@actions/core@1.10.1)(@actions/exec@1.1.1)
 
 devDependencies:
   '@biomejs/biome':
@@ -584,8 +584,8 @@ packages:
     hasBin: true
     dev: true
 
-  /actions-swing@0.0.5(@actions/core@1.10.1)(@actions/exec@1.1.1):
-    resolution: {integrity: sha512-JnOnk09lhKLTnWJS28YX4c9Jl1jczyHxhRHtcxKrX6wcXukO2K/ZlRoHgcmv5ccNyISBIVJE6I/W31VcmrmFaA==}
+  /actions-swing@0.0.6(@actions/core@1.10.1)(@actions/exec@1.1.1):
+    resolution: {integrity: sha512-2p76nGHdCWUrOyktggBGn/gH/rUvZWsluLmifOw8C4syrTh8FFjfb95bmhZ6ScHPphNEuBak8UHXjErDPKTOgg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@actions/core': '>=1'

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -52,7 +52,10 @@ const SUSE_BASED_DEPENDENT_PACKAGES = [
   "mozilla-nss",
 ];
 
-const installDependencies = async (platform: Platform): Promise<void> => {
+const installDependencies = async (
+  platform: Platform,
+  { noSudo }: { noSudo: boolean },
+) => {
   if (platform.os !== "linux") {
     core.warning(
       `install-dependencies is only supported on Linux, but current platform is ${platform.os}`,
@@ -79,8 +82,9 @@ const installDependencies = async (platform: Platform): Promise<void> => {
     }
     throw new Error(`Unsupported OS: ${osReleaseId}`);
   })();
+  const sudo = !noSudo && process.getuid?.() !== 0;
 
-  await pkg.install(packages);
+  await pkg.install(packages, { sudo });
 };
 
 export { installDependencies };

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,10 +50,11 @@ async function run(): Promise<void> {
     const platform = getPlatform();
     const flagInstallDependencies =
       core.getInput("install-dependencies") === "true";
+    const noSudo = core.getInput("no-sudo") === "true";
 
     if (flagInstallDependencies) {
       core.info("Installing dependencies");
-      await installDependencies(platform);
+      await installDependencies(platform, { noSudo });
     }
 
     core.info(`Setup chromium ${version}`);


### PR DESCRIPTION
This change is to install dependencies with `sudo` for non-root users by default. The action identify the current UID and enable `sudo` if the UID is not 0. Users can disable using `sudo` by setting the `no-sudo: true` in the action input.

```yaml
steps:
  - uses: browser-actions/setup-chrome@v1
    with:
      chrome-version: 120
      install-dependencies: true
      no-sudo: true
```

Close #544 