### PR TITLE
fix: try to install browser version when user will not install ChromeDriver

### DIFF
--- a/__test__/chrome_for_testing.test.ts
+++ b/__test__/chrome_for_testing.test.ts
@@ -41,7 +41,7 @@ describe("KnownGoodVersionResolver", () => {
         os: "linux",
         arch: "amd64",
       });
-      const resolved = await resolver.resolve(spec);
+      const resolved = await resolver.resolveBrowserAndDriver(spec);
       expect(resolved?.version).toEqual(version);
       expect(resolved?.browserDownloadURL).toEqual(browserURL);
       expect(resolved?.driverDownloadURL).toEqual(driverURL);
@@ -53,9 +53,25 @@ describe("KnownGoodVersionResolver", () => {
       os: "linux",
       arch: "amd64",
     });
-    await resolver.resolve("120.0.6099.5");
-    await resolver.resolve("120.0.6099.18");
+    await resolver.resolveBrowserAndDriver("120.0.6099.5");
+    await resolver.resolveBrowserAndDriver("120.0.6099.18");
     expect(getJsonSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("should resolve only browser download URL", async () => {
+    const resolver = new KnownGoodVersionResolver({
+      os: "linux",
+      arch: "amd64",
+    });
+
+    const resolved1 = await resolver.resolveBrowserAndDriver("113.0.5672.0");
+    expect(resolved1).toBeUndefined();
+
+    const resolved2 = await resolver.resolveBrowserOnly("113.0.5672.0");
+    expect(resolved2?.version).toEqual("113.0.5672.0");
+    expect(resolved2?.browserDownloadURL).toEqual(
+      "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/113.0.5672.0/linux64/chrome-linux64.zip",
+    );
   });
 
   test("unsupported platform", async () => {

--- a/__test__/version_installer.test.ts
+++ b/__test__/version_installer.test.ts
@@ -32,10 +32,13 @@ afterEach(() => {
 });
 
 describe("KnownGoodVersionInstaller", () => {
-  const installer = new KnownGoodVersionInstaller({
-    os: "linux",
-    arch: "amd64",
-  });
+  const installer = new KnownGoodVersionInstaller(
+    {
+      os: "linux",
+      arch: "amd64",
+    },
+    { resolveBrowserVersionOnly: false },
+  );
 
   test("checkInstalledBrowser should return installed path if installed", async () => {
     cacheFindSpy.mockResolvedValue(
@@ -100,6 +103,19 @@ describe("KnownGoodVersionInstaller", () => {
     expect(tcDownloadToolSpy).toHaveBeenCalled();
   });
 
+  test("downloadDriver should throw an error when browser only mode", async () => {
+    const installer = new KnownGoodVersionInstaller(
+      {
+        os: "linux",
+        arch: "amd64",
+      },
+      { resolveBrowserVersionOnly: true },
+    );
+    expect(installer.downloadDriver("120.0.6099.x")).rejects.toThrowError(
+      "Unexpectedly trying to download chromedriver",
+    );
+  });
+
   test("installDriver should install driver", async () => {
     tcExtractZipSpy.mockImplementation(async () => "/tmp/extracted");
     cacheCacheDirSpy.mockImplementation(async () => "/path/to/chromedriver");
@@ -117,5 +133,18 @@ describe("KnownGoodVersionInstaller", () => {
       "chromedriver",
       "120.0.6099.56",
     );
+  });
+
+  test("installDriver should throw an error when browser only mode", async () => {
+    const installer = new KnownGoodVersionInstaller(
+      {
+        os: "linux",
+        arch: "amd64",
+      },
+      { resolveBrowserVersionOnly: true },
+    );
+    expect(
+      installer.installDriver("120.0.6099.x", "/tmp/chromedriver.zip"),
+    ).rejects.toThrowError("Unexpectedly trying to install chromedriver");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ const hasErrorMessage = (e: unknown): e is { message: string | Error } => {
   return typeof e === "object" && e !== null && "message" in e;
 };
 
-const getInstaller = (platform: Platform, version: string) => {
+const getInstaller = (
+  platform: Platform,
+  version: string,
+  { resolveBrowserVersionOnly }: { resolveBrowserVersionOnly: boolean },
+) => {
   const spec = parse(version);
   switch (spec.value.type) {
     case "latest":
@@ -34,7 +38,9 @@ const getInstaller = (platform: Platform, version: string) => {
     case "snapshot":
       return new SnapshotInstaller(platform);
     case "four-parts":
-      return new KnownGoodVersionInstaller(platform);
+      return new KnownGoodVersionInstaller(platform, {
+        resolveBrowserVersionOnly,
+      });
   }
 };
 
@@ -136,7 +142,10 @@ async function run(): Promise<void> {
 
     core.info(`Setup chrome ${version}`);
 
-    const installer = getInstaller(platform, version);
+    const resolveBrowserVersionOnly = !flgInstallChromedriver;
+    const installer = getInstaller(platform, version, {
+      resolveBrowserVersionOnly,
+    });
     const browserBinPath = await installBrowser(installer, version);
     const actualBrowserVersion = await testVersion(platform, browserBinPath);
 

--- a/src/version_installer.ts
+++ b/src/version_installer.ts
@@ -94,11 +94,6 @@ export class KnownGoodVersionInstaller implements Installer {
     if (!resolved) {
       throw new Error(`Version ${version} not found in known good versions`);
     }
-    if (!resolved.driverDownloadURL) {
-      throw new Error(
-        `Version ${version} does not have a known good chromedriver version`,
-      );
-    }
 
     core.info(
       `Acquiring chromedriver ${resolved.version} from ${resolved.driverDownloadURL}`,

--- a/src/version_installer.ts
+++ b/src/version_installer.ts
@@ -7,12 +7,16 @@ import type { DownloadResult, InstallResult, Installer } from "./installer";
 import { OS, type Platform } from "./platform";
 
 export class KnownGoodVersionInstaller implements Installer {
-  private readonly versionResolver: KnownGoodVersionResolver;
   private readonly platform: Platform;
+  private readonly resolveBrowserVersionOnly: boolean;
+  private readonly versionResolver: KnownGoodVersionResolver;
 
-  constructor(platform: Platform) {
+  constructor(
+    platform: Platform,
+    { resolveBrowserVersionOnly }: { resolveBrowserVersionOnly: boolean },
+  ) {
     this.platform = platform;
-
+    this.resolveBrowserVersionOnly = resolveBrowserVersionOnly;
     this.versionResolver = new KnownGoodVersionResolver(this.platform);
   }
 
@@ -26,7 +30,9 @@ export class KnownGoodVersionInstaller implements Installer {
   }
 
   async downloadBrowser(version: string): Promise<DownloadResult> {
-    const resolved = await this.versionResolver.resolve(version);
+    const resolved = this.resolveBrowserVersionOnly
+      ? await this.versionResolver.resolveBrowserOnly(version)
+      : await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
       throw new Error(`Version ${version} not found in known good versions`);
     }
@@ -42,7 +48,9 @@ export class KnownGoodVersionInstaller implements Installer {
     version: string,
     archive: string,
   ): Promise<InstallResult> {
-    const resolved = await this.versionResolver.resolve(version);
+    const resolved = this.resolveBrowserVersionOnly
+      ? await this.versionResolver.resolveBrowserOnly(version)
+      : await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
       throw new Error(`Version ${version} not found in known good versions`);
     }
@@ -77,9 +85,19 @@ export class KnownGoodVersionInstaller implements Installer {
   }
 
   async downloadDriver(version: string): Promise<DownloadResult> {
-    const resolved = await this.versionResolver.resolve(version);
+    if (this.resolveBrowserVersionOnly) {
+      throw new Error("Unexpectedly trying to download chromedriver");
+    }
+
+    const resolved =
+      await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
       throw new Error(`Version ${version} not found in known good versions`);
+    }
+    if (!resolved.driverDownloadURL) {
+      throw new Error(
+        `Version ${version} does not have a known good chromedriver version`,
+      );
     }
 
     core.info(
@@ -93,7 +111,12 @@ export class KnownGoodVersionInstaller implements Installer {
     version: string,
     archive: string,
   ): Promise<InstallResult> {
-    const resolved = await this.versionResolver.resolve(version);
+    if (this.resolveBrowserVersionOnly) {
+      throw new Error("Unexpectedly trying to install chromedriver");
+    }
+
+    const resolved =
+      await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
       throw new Error(`Version ${version} not found in known good versions`);
     }


### PR DESCRIPTION
Installing ChromeDriver (https://github.com/browser-actions/setup-chrome/pull/548) resolves a version which includes both the Chrome browser and ChromeDriver download URLs from [known-good-versions-with-downloads.json](https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json). Before this change, user was able to install a version which includes only chrome download URL. The action should be able to download chrome browser if the user does specifies "install-chromedriver: false" and matched version does not include ChromeDriver. This PR enables to install browser if the version does not include ChromeDriver on "install-chromedriver: false".

Close #550 