### PR TITLE
chore(ci): migrate release-please-action repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
The [google-github-actions/release-please-action](https://github.com/google-github-actions/release-please-action) is moved under googleapis org and now deprecated. 