### PR TITLE
fix: support ubuntu 24

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -94,7 +94,7 @@ const installDependencies = async (
       case "linuxmint":
         return DEBIAN_BASED_DEPENDENT_PACKAGES;
       case "ubuntu":
-        return versionId === "24"
+        return parseInt(versionId.split(".")[0], 10) >= 24
           ? UBUNTU_24_DEPENDENT_PACKAGES
           : DEBIAN_BASED_DEPENDENT_PACKAGES;
       case "opensuse":

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -21,14 +21,14 @@ const DEBIAN_BASED_DEPENDENT_PACKAGES = [
 
 const UBUNTU_24_DEPENDENT_PACKAGES = [
   "libasound2t64",
-  "libatk-bridge2.0-0",
-  "libatk1.0-0",
+  "libatk-bridge2.0-0t64",
+  "libatk1.0-0t64",
   "libcairo2",
-  "libcups2",
+  "libcups2t64",
   "libdbus-1-3",
   "libexpat1",
   "libgbm1",
-  "libglib2.0-0",
+  "libglib2.0-0t64",
   "libnss3",
   "libpango-1.0-0",
   "libxcomposite1",

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -19,6 +19,25 @@ const DEBIAN_BASED_DEPENDENT_PACKAGES = [
   "xdg-utils",
 ];
 
+const UBUNTU_24_DEPENDENT_PACKAGES = [
+  "libasound2t64",
+  "libatk-bridge2.0-0",
+  "libatk1.0-0",
+  "libcairo2",
+  "libcups2",
+  "libdbus-1-3",
+  "libexpat1",
+  "libgbm1",
+  "libglib2.0-0",
+  "libnss3",
+  "libpango-1.0-0",
+  "libxcomposite1",
+  "libxdamage1",
+  "libxfixes3",
+  "libxkbcommon0",
+  "libxrandr2",
+];
+
 const FEDORA_BASED_DEPENDENT_PACKAGES = [
   "alsa-lib",
   "atk",
@@ -64,23 +83,26 @@ const installDependencies = async (
   }
 
   const packages = await (async () => {
-    const osReleaseId = await runtime.getOsReleaseId();
-    switch (osReleaseId) {
+    const { ID: id, VERSION_ID: versionId } = await runtime.loadOsRelease();
+    switch (id) {
       case "rhel":
       case "centos":
       case "ol":
       case "fedora":
         return FEDORA_BASED_DEPENDENT_PACKAGES;
       case "debian":
-      case "ubuntu":
       case "linuxmint":
         return DEBIAN_BASED_DEPENDENT_PACKAGES;
+      case "ubuntu":
+        return versionId === "24"
+          ? UBUNTU_24_DEPENDENT_PACKAGES
+          : DEBIAN_BASED_DEPENDENT_PACKAGES;
       case "opensuse":
       case "opensuse-leap":
       case "sles":
         return SUSE_BASED_DEPENDENT_PACKAGES;
     }
-    throw new Error(`Unsupported OS: ${osReleaseId}`);
+    throw new Error(`Unsupported OS: ${id}`);
   })();
   const sudo = !noSudo && process.getuid?.() !== 0;
 

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -94,7 +94,7 @@ const installDependencies = async (
       case "linuxmint":
         return DEBIAN_BASED_DEPENDENT_PACKAGES;
       case "ubuntu":
-        return parseInt(versionId.split(".")[0], 10) >= 24
+        return Number.parseInt(versionId.split(".")[0], 10) >= 24
           ? UBUNTU_24_DEPENDENT_PACKAGES
           : DEBIAN_BASED_DEPENDENT_PACKAGES;
       case "opensuse":


### PR DESCRIPTION
It support `install-dependencies: true` with Ubuntu 24.04.

Ubuntu 24.04 has some changes on packages names to prevent the Year 2038 problem. It can break compatibilities with Ubuntu 22.04 such as reported in #618.
https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890/1

Close #618 