### PR TITLE
feat!: Use chrome for testing as default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        version: ["", 1295939, 120, dev]
+        version: ["", 1295939, 120, dev, latest]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This action sets-up Google Chrome/Chromium for GitHub Actions. This action suppo
 ## Usage
 
 Here is a basic usage.
-The action installs the latest build by default.
+The action installs the stable version of Chrome for Testing by default.
 
 ```yaml
 steps:
@@ -58,9 +58,9 @@ steps:
 
 The action supports the following version formats:
 
-- The latest snapshot `latest` (default).
+- The latest snapshot `latest`.
 - Commit positions like `1295939`.  You can find commit positions from [here][snapshots].
-- Google Chrome release channels: `stable`, `beta`, `dev` and `canary`
+- Google Chrome release channels: `stable` (default), `beta`, `dev` and `canary`
 - Specific versions: `119`, `120.0.6099`, `121.0.6100.0`.  The version are resolved by [Chrome for Testing][].
 
 [Chrome for Testing]: https://googlechromelabs.github.io/chrome-for-testing/

--- a/__test__/channel_linux.test.ts
+++ b/__test__/channel_linux.test.ts
@@ -25,11 +25,11 @@ describe("LinuxChannelInstaller", () => {
     });
 
     test("return install result if installed", async () => {
-      cacheFindSpy.mockResolvedValue("/path/to/chromium");
+      cacheFindSpy.mockResolvedValue("/path/to/chrome");
 
       const result = await installer.checkInstalledBrowser("stable");
 
-      expect(result).toEqual({ root: "/path/to/chromium", bin: "chrome" });
+      expect(result).toEqual({ root: "/path/to/chrome", bin: "chrome" });
     });
   });
 
@@ -59,17 +59,17 @@ describe("LinuxChannelInstaller", () => {
 
     test("install stable version", async () => {
       tcExtractZipSpy.mockResolvedValue("/deb-abcdef");
-      cacheCacheDirSpy.mockResolvedValue("/path/to/chromium");
+      cacheCacheDirSpy.mockResolvedValue("/path/to/chrome");
 
       const result = await installer.installBrowser(
         "stable",
         "/path/to/downloaded.deb",
       );
 
-      expect(result).toEqual({ root: "/path/to/chromium", bin: "chrome" });
+      expect(result).toEqual({ root: "/path/to/chrome", bin: "chrome" });
       expect(cacheCacheDirSpy).toHaveBeenCalledWith(
         "/deb-abcdef/chrome-linux64",
-        "chromium",
+        "chrome",
         "stable",
       );
     });

--- a/__test__/channel_macos.test.ts
+++ b/__test__/channel_macos.test.ts
@@ -77,7 +77,7 @@ describe("MacOSChannelInstaller", () => {
       });
       expect(cacheCacheDirSpy).toHaveBeenCalledWith(
         "/path/to/archive/Google Chrome for Testing.app",
-        "chromium",
+        "chrome",
         "stable",
       );
     });

--- a/__test__/channel_macos.test.ts
+++ b/__test__/channel_macos.test.ts
@@ -76,7 +76,7 @@ describe("MacOSChannelInstaller", () => {
         bin: "Contents/MacOS/Google Chrome for Testing",
       });
       expect(cacheCacheDirSpy).toHaveBeenCalledWith(
-        "/path/to/archive/Google Chrome for Testing.app",
+        "/path/to/archive/chrome-mac-x64/Google Chrome for Testing.app",
         "chrome",
         "stable",
       );

--- a/__test__/channel_macos.test.ts
+++ b/__test__/channel_macos.test.ts
@@ -1,5 +1,3 @@
-import * as fs from "node:fs";
-import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import * as cache from "../src/cache";
@@ -9,8 +7,6 @@ const cacheFindSpy = vi.spyOn(cache, "find");
 const cacheCacheDirSpy = vi.spyOn(cache, "cacheDir");
 const tcDownloadToolSpy = vi.spyOn(tc, "downloadTool");
 const tcExtractZipSpy = vi.spyOn(tc, "extractZip");
-const fsSymlinkSpy = vi.spyOn(fs.promises, "symlink");
-const execSpy = vi.spyOn(exec, "exec");
 
 afterEach(() => {
   vi.resetAllMocks();
@@ -38,7 +34,7 @@ describe("MacOSChannelInstaller", () => {
 
       expect(result).toEqual({
         root: "/path/to/Chromium.app",
-        bin: "Contents/MacOS/chrome",
+        bin: "Contents/MacOS/Google Chrome for Testing",
       });
     });
   });
@@ -67,9 +63,8 @@ describe("MacOSChannelInstaller", () => {
     });
 
     test("install stable version", async () => {
-      execSpy.mockResolvedValue(0);
-      fsSymlinkSpy.mockResolvedValue();
-      cacheCacheDirSpy.mockResolvedValue("/path/to/Chromium.app");
+      tcExtractZipSpy.mockResolvedValue("/path/to/archive");
+      cacheCacheDirSpy.mockResolvedValue("/path/to/Chromium for Testing.app");
 
       const result = await installer.installBrowser(
         "stable",
@@ -77,11 +72,11 @@ describe("MacOSChannelInstaller", () => {
       );
 
       expect(result).toEqual({
-        root: "/path/to/Chromium.app",
-        bin: "Contents/MacOS/chrome",
+        root: "/path/to/Chromium for Testing.app",
+        bin: "Contents/MacOS/Google Chrome for Testing",
       });
       expect(cacheCacheDirSpy).toHaveBeenCalledWith(
-        "/Volumes/downloaded.dmg/Google Chrome.app",
+        "/path/to/archive/Google Chrome for Testing.app",
         "chromium",
         "stable",
       );

--- a/__test__/channel_windows.test.ts
+++ b/__test__/channel_windows.test.ts
@@ -1,17 +1,14 @@
 import * as fs from "node:fs";
-import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import * as cache from "../src/cache";
 import { WindowsChannelInstaller } from "../src/channel_windows";
 
-const fsStatSpy = vi.spyOn(fs.promises, "stat");
 const fsRenameSpy = vi.spyOn(fs.promises, "rename");
 const tcDownloadToolSpy = vi.spyOn(tc, "downloadTool");
 const tcExtractZipSpy = vi.spyOn(tc, "extractZip");
 const cacheFindSpy = vi.spyOn(cache, "find");
 const cacheCacheDirSpy = vi.spyOn(cache, "cacheDir");
-const execSpy = vi.spyOn(exec, "exec");
 
 afterEach(() => {
   vi.resetAllMocks();
@@ -25,21 +22,20 @@ describe("WindowsChannelInstaller", () => {
 
   describe("checkInstalledBrowser", () => {
     test("returns undefined if the root directory does not exist", async () => {
+      cacheFindSpy.mockResolvedValue(undefined);
+
       const result = await installer.checkInstalledBrowser("stable");
       expect(result).toBe(undefined);
     });
 
     test("returns the root directory and bin path if the root directory exists", async () => {
-      fsStatSpy.mockResolvedValue(undefined);
+      cacheFindSpy.mockResolvedValue("C:\\path\\to\\chrome");
 
       const result = await installer.checkInstalledBrowser("stable");
       expect(result).toEqual({
-        root: "C:\\Program Files\\Google\\Chrome\\Application",
+        root: "C:\\path\\to\\chrome",
         bin: "chrome.exe",
       });
-      expect(fsStatSpy).toHaveBeenCalledWith(
-        "C:\\Program Files\\Google\\Chrome\\Application",
-      );
     });
   });
 
@@ -70,21 +66,17 @@ describe("WindowsChannelInstaller", () => {
     });
 
     test("install the stable version of Chrome", async () => {
-      execSpy.mockResolvedValue(undefined);
-      fsRenameSpy.mockResolvedValue(undefined);
+      tcExtractZipSpy.mockResolvedValue("C:\\path\\to\\extract\\directory");
+      cacheCacheDirSpy.mockResolvedValue("C:\\path\\to\\chrome");
 
       const result = await installer.installBrowser(
         "stable",
-        "C:\\path\\to\\downloaded\\installer.exe",
+        "C:\\path\\to\\downloaded\\file.zip",
       );
       expect(result).toEqual({
-        root: "C:\\Program Files\\Google\\Chrome\\Application",
+        root: "C:\\path\\to\\chrome",
         bin: "chrome.exe",
       });
-      expect(execSpy).toHaveBeenCalledWith(
-        "C:\\path\\to\\downloaded\\installer.exe",
-        ["/silent", "/install"],
-      );
     });
   });
 
@@ -97,11 +89,11 @@ describe("WindowsChannelInstaller", () => {
     });
 
     test("return install result if installed", async () => {
-      cacheFindSpy.mockResolvedValue("/path/to/chromedriver");
+      cacheFindSpy.mockResolvedValue("C:\\path\\to\\chromedriver");
 
       const result = await installer.checkInstalledDriver("stable");
       expect(result).toEqual({
-        root: "/path/to/chromedriver",
+        root: "C:\\path\\to\\chromedriver",
         bin: "chromedriver",
       });
     });

--- a/__test__/latest_installer.test.ts
+++ b/__test__/latest_installer.test.ts
@@ -26,14 +26,14 @@ describe("LatestInstaller", () => {
 
       const result = await installer.checkInstalledBrowser("latest");
       expect(result).toBe(undefined);
-      expect(cacheFindSpy).toHaveBeenCalledWith("chromium", "123456");
+      expect(cacheFindSpy).toHaveBeenCalledWith("chrome", "123456");
     });
 
     test("returns install result if installed", async () => {
-      cacheFindSpy.mockResolvedValue("/path/to/chromium");
+      cacheFindSpy.mockResolvedValue("/path/to/chrome");
 
       const result = await installer.checkInstalledBrowser("latest");
-      expect(result).toEqual({ root: "/path/to/chromium", bin: "chrome" });
+      expect(result).toEqual({ root: "/path/to/chrome", bin: "chrome" });
     });
   });
 
@@ -52,17 +52,17 @@ describe("LatestInstaller", () => {
   describe("installBrowser", () => {
     test("installs the browser", async () => {
       tcExtractZipSpy.mockResolvedValue("/path/to/ext");
-      cacheCacheDirSpy.mockResolvedValue("/path/to/chromium");
+      cacheCacheDirSpy.mockResolvedValue("/path/to/chrome");
 
       const result = await installer.installBrowser(
         "latest",
         "/tmp/chrome.zip",
       );
-      expect(result).toEqual({ root: "/path/to/chromium", bin: "chrome" });
+      expect(result).toEqual({ root: "/path/to/chrome", bin: "chrome" });
       expect(tcExtractZipSpy).toHaveBeenCalled();
       expect(cacheCacheDirSpy).toHaveBeenCalledWith(
         "/path/to/ext/chrome-linux",
-        "chromium",
+        "chrome",
         "123456",
       );
     });

--- a/__test__/snapshot_installer.test.ts
+++ b/__test__/snapshot_installer.test.ts
@@ -24,10 +24,10 @@ describe("SnapshotInstaller", () => {
     });
 
     test("returns install result if installed", async () => {
-      cacheFindSpy.mockResolvedValue("/path/to/chromium");
+      cacheFindSpy.mockResolvedValue("/path/to/chrome");
 
       const result = await installer.checkInstalledBrowser("123456");
-      expect(result).toEqual({ root: "/path/to/chromium", bin: "chrome" });
+      expect(result).toEqual({ root: "/path/to/chrome", bin: "chrome" });
     });
   });
 
@@ -44,13 +44,13 @@ describe("SnapshotInstaller", () => {
   describe("installBrowser", () => {
     test("installs the browser", async () => {
       tcExtractZipSpy.mockResolvedValue("/path/to/ext");
-      cacheCacheDirSpy.mockResolvedValue("/path/to/chromium");
+      cacheCacheDirSpy.mockResolvedValue("/path/to/chrome");
 
       const result = await installer.installBrowser(
         "123456",
         "/tmp/chrome.zip",
       );
-      expect(result).toEqual({ root: "/path/to/chromium", bin: "chrome" });
+      expect(result).toEqual({ root: "/path/to/chrome", bin: "chrome" });
       expect(tcExtractZipSpy).toHaveBeenCalled();
       expect(cacheCacheDirSpy).toHaveBeenCalled();
     });

--- a/__test__/version_installer.test.ts
+++ b/__test__/version_installer.test.ts
@@ -42,36 +42,36 @@ describe("KnownGoodVersionInstaller", () => {
 
   test("checkInstalledBrowser should return installed path if installed", async () => {
     cacheFindSpy.mockResolvedValue(
-      "/opt/hostedtoolcache/setup-chrome/chromium/120.0.6099.56/x64",
+      "/opt/hostedtoolcache/setup-chrome/chrome/120.0.6099.56/x64",
     );
 
     const installed = await installer.checkInstalledBrowser("120.0.6099.x");
     expect(installed?.root).toEqual(
-      "/opt/hostedtoolcache/setup-chrome/chromium/120.0.6099.56/x64",
+      "/opt/hostedtoolcache/setup-chrome/chrome/120.0.6099.56/x64",
     );
-    expect(cacheFindSpy).toHaveBeenCalledWith("chromium", "120.0.6099.x");
+    expect(cacheFindSpy).toHaveBeenCalledWith("chrome", "120.0.6099.x");
   });
 
   test("downloadBrowser should download browser archive", async () => {
-    tcDownloadToolSpy.mockImplementation(async () => "/tmp/chromium.zip");
+    tcDownloadToolSpy.mockImplementation(async () => "/tmp/chrome.zip");
 
     const downloaded = await installer.downloadBrowser("120.0.6099.x");
-    expect(downloaded?.archive).toEqual("/tmp/chromium.zip");
+    expect(downloaded?.archive).toEqual("/tmp/chrome.zip");
     expect(tcDownloadToolSpy).toHaveBeenCalled();
   });
 
   test("installDriver should install browser", async () => {
     tcExtractZipSpy.mockImplementation(async () => "/tmp/extracted");
-    cacheCacheDirSpy.mockImplementation(async () => "/path/to/chromium");
+    cacheCacheDirSpy.mockImplementation(async () => "/path/to/chrome");
 
     const installed = await installer.installBrowser(
       "120.0.6099.x",
-      "/tmp/chromium.zip",
+      "/tmp/chrome.zip",
     );
-    expect(installed).toEqual({ root: "/path/to/chromium", bin: "chrome" });
+    expect(installed).toEqual({ root: "/path/to/chrome", bin: "chrome" });
     expect(cacheCacheDirSpy).toHaveBeenCalledWith(
       "/tmp/extracted/chrome-linux64",
-      "chromium",
+      "chrome",
       "120.0.6099.56",
     );
   });

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   chrome-version:
     description: |-
       The Google Chrome/Chromium version to install and use.
-    default: latest
+    default: stable
     required: false
   install-dependencies:
     description: |-

--- a/src/channel_linux.ts
+++ b/src/channel_linux.ts
@@ -41,7 +41,7 @@ export class LinuxChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in chrome for testing versions`,
+        `Version ${version} not found in chrome for testing versions for ${this.platform.os} ${this.platform.arch}`,
       );
     }
 
@@ -85,7 +85,7 @@ export class LinuxChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in chrome for testing versions`,
+        `Version ${version} not found in chrome for testing versions for ${this.platform.os} ${this.platform.arch}`,
       );
     }
 

--- a/src/channel_linux.ts
+++ b/src/channel_linux.ts
@@ -1,8 +1,5 @@
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import * as core from "@actions/core";
-import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
 import * as cache from "./cache";
 import { LastKnownGoodVersionResolver } from "./chrome_for_testing";
@@ -26,6 +23,10 @@ export class LinuxChannelInstaller implements Installer {
   async checkInstalledBrowser(
     version: string,
   ): Promise<InstallResult | undefined> {
+    if (!isReleaseChannelName(version)) {
+      throw new Error(`Unexpected version: ${version}`);
+    }
+
     const root = await cache.find("chromium", version);
     if (root) {
       return { root, bin: "chrome" };
@@ -36,25 +37,18 @@ export class LinuxChannelInstaller implements Installer {
     if (!isReleaseChannelName(version)) {
       throw new Error(`Unexpected version: ${version}`);
     }
-    if (version === "canary") {
+
+    const resolved = await this.versionResolver.resolve(version);
+    if (!resolved) {
       throw new Error(
-        `Chrome ${version} not supported for platform ${this.platform.os} ${this.platform.arch}`,
+        `Version ${version} not found in chrome for testing versions`,
       );
     }
 
-    const url = (() => {
-      switch (version) {
-        case "stable":
-          return "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb";
-        case "beta":
-          return "https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb";
-        case "dev":
-          return "https://dl.google.com/linux/direct/google-chrome-unstable_current_amd64.deb";
-      }
-    })();
-
-    core.info(`Acquiring chrome ${version} from ${url}`);
-    const archive = await tc.downloadTool(url);
+    core.info(
+      `Acquiring chrome ${version} from ${resolved.browserDownloadURL}`,
+    );
+    const archive = await tc.downloadTool(resolved.browserDownloadURL);
     return { archive };
   }
 
@@ -65,27 +59,14 @@ export class LinuxChannelInstaller implements Installer {
     if (!isReleaseChannelName(version)) {
       throw new Error(`Unexpected version: ${version}`);
     }
-    if (version === "canary") {
-      throw new Error(`Chrome ${version} not supported for Linux`);
-    }
 
-    const tmpdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "deb-"));
-    const extdir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "chrome-"));
-    await exec.exec("ar", ["x", archive], { cwd: tmpdir });
-    await exec.exec("tar", [
-      "-xf",
-      path.join(tmpdir, "data.tar.xz"),
-      "--directory",
-      extdir,
-      "--strip-components",
-      "4",
-      "./opt/google",
-    ]);
+    const extPath = await tc.extractZip(archive);
+    const extAppRoot = path.join(
+      extPath,
+      `chrome-${this.versionResolver.platformString}`,
+    );
 
-    // remove broken symlink
-    await fs.promises.unlink(path.join(extdir, "google-chrome"));
-
-    const root = await cache.cacheDir(extdir, "chromium", version);
+    const root = await cache.cacheDir(extAppRoot, "chromium", version);
     core.info(`Successfully Installed chromium to ${root}`);
 
     return { root, bin: "chrome" };
@@ -104,7 +85,7 @@ export class LinuxChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in the known good versions`,
+        `Version ${version} not found in chrome for testing versions`,
       );
     }
 

--- a/src/channel_linux.ts
+++ b/src/channel_linux.ts
@@ -27,7 +27,7 @@ export class LinuxChannelInstaller implements Installer {
       throw new Error(`Unexpected version: ${version}`);
     }
 
-    const root = await cache.find("chromium", version);
+    const root = await cache.find("chrome", version);
     if (root) {
       return { root, bin: "chrome" };
     }
@@ -66,8 +66,8 @@ export class LinuxChannelInstaller implements Installer {
       `chrome-${this.versionResolver.platformString}`,
     );
 
-    const root = await cache.cacheDir(extAppRoot, "chromium", version);
-    core.info(`Successfully Installed chromium to ${root}`);
+    const root = await cache.cacheDir(extAppRoot, "chrome", version);
+    core.info(`Successfully Installed chrome to ${root}`);
 
     return { root, bin: "chrome" };
   }

--- a/src/channel_macos.ts
+++ b/src/channel_macos.ts
@@ -10,12 +10,15 @@ import { isReleaseChannelName } from "./version";
 export class MacOSChannelInstaller implements Installer {
   private readonly versionResolver: LastKnownGoodVersionResolver;
 
+  private readonly platform: Platform;
+
   constructor(platform: Platform) {
     if (platform.os !== "darwin") {
       throw new Error(`Unexpected OS: ${platform.os}`);
     }
 
     this.versionResolver = new LastKnownGoodVersionResolver(platform);
+    this.platform = platform;
   }
 
   async checkInstalledBrowser(
@@ -38,7 +41,7 @@ export class MacOSChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in chrome for testing versions`,
+        `Version ${version} not found in chrome for testing versions for ${this.platform.os} ${this.platform.arch}`,
       );
     }
 
@@ -83,7 +86,7 @@ export class MacOSChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in chrome for testing versions`,
+        `Version ${version} not found in chrome for testing versions for ${this.platform.os} ${this.platform.arch}`,
       );
     }
 

--- a/src/channel_macos.ts
+++ b/src/channel_macos.ts
@@ -58,7 +58,11 @@ export class MacOSChannelInstaller implements Installer {
     }
 
     const extPath = await tc.extractZip(archive);
-    const extAppRoot = path.join(extPath, "Google Chrome for Testing.app");
+    const extAppRoot = path.join(
+      extPath,
+      `chrome-${this.versionResolver.platformString}`,
+      "Google Chrome for Testing.app",
+    );
 
     const root = await cache.cacheDir(extAppRoot, "chrome", version);
     core.info(`Successfully Installed chrome to ${root}`);

--- a/src/channel_macos.ts
+++ b/src/channel_macos.ts
@@ -24,7 +24,7 @@ export class MacOSChannelInstaller implements Installer {
     if (!isReleaseChannelName(version)) {
       throw new Error(`Unexpected version: ${version}`);
     }
-    const root = await cache.find("chromium", version);
+    const root = await cache.find("chrome", version);
     if (root) {
       return { root, bin: "Contents/MacOS/Google Chrome for Testing" };
     }
@@ -60,8 +60,8 @@ export class MacOSChannelInstaller implements Installer {
     const extPath = await tc.extractZip(archive);
     const extAppRoot = path.join(extPath, "Google Chrome for Testing.app");
 
-    const root = await cache.cacheDir(extAppRoot, "chromium", version);
-    core.info(`Successfully Installed chromium to ${root}`);
+    const root = await cache.cacheDir(extAppRoot, "chrome", version);
+    core.info(`Successfully Installed chrome to ${root}`);
 
     return { root, bin: "Contents/MacOS/Google Chrome for Testing" };
   }

--- a/src/channel_windows.ts
+++ b/src/channel_windows.ts
@@ -27,7 +27,7 @@ export class WindowsChannelInstaller implements Installer {
       throw new Error(`Unexpected version: ${version}`);
     }
 
-    const root = await cache.find("chromium", version);
+    const root = await cache.find("chrome", version);
     if (root) {
       return { root, bin: "chrome.exe" };
     }
@@ -66,8 +66,8 @@ export class WindowsChannelInstaller implements Installer {
       `chrome-${this.versionResolver.platformString}`,
     );
 
-    const root = await cache.cacheDir(extAppRoot, "chromium", version);
-    core.info(`Successfully Installed chromium to ${root}`);
+    const root = await cache.cacheDir(extAppRoot, "chrome", version);
+    core.info(`Successfully Installed chrome to ${root}`);
 
     return { root, bin: "chrome.exe" };
   }

--- a/src/channel_windows.ts
+++ b/src/channel_windows.ts
@@ -41,7 +41,7 @@ export class WindowsChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in chrome for testing versions`,
+        `Version ${version} not found in chrome for testing versions for ${this.platform.os} ${this.platform.arch}`,
       );
     }
 
@@ -85,7 +85,7 @@ export class WindowsChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in chrome for testing versions`,
+        `Version ${version} not found in chrome for testing versions for ${this.platform.os} ${this.platform.arch}`,
       );
     }
 

--- a/src/channel_windows.ts
+++ b/src/channel_windows.ts
@@ -1,19 +1,11 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
 import * as core from "@actions/core";
-import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
 import * as cache from "./cache";
 import { LastKnownGoodVersionResolver } from "./chrome_for_testing";
 import type { DownloadResult, InstallResult, Installer } from "./installer";
-import { Arch, type Platform } from "./platform";
-import { type ReleaseChannelName, isReleaseChannelName } from "./version";
-
-const isENOENT = (e: unknown): boolean => {
-  return (
-    typeof e === "object" && e !== null && "code" in e && e.code === "ENOENT"
-  );
-};
+import type { Platform } from "./platform";
+import { isReleaseChannelName } from "./version";
 
 export class WindowsChannelInstaller implements Installer {
   private readonly platform: Platform;
@@ -35,85 +27,29 @@ export class WindowsChannelInstaller implements Installer {
       throw new Error(`Unexpected version: ${version}`);
     }
 
-    const root = this.browserRootDir(version);
-    try {
-      await fs.promises.stat(root);
-    } catch (e) {
-      if (isENOENT(e)) {
-        return undefined;
-      }
-      throw e;
+    const root = await cache.find("chromium", version);
+    if (root) {
+      return { root, bin: "chrome.exe" };
     }
-
-    return { root, bin: "chrome.exe" };
   }
 
   async downloadBrowser(version: string): Promise<DownloadResult> {
     if (!isReleaseChannelName(version)) {
       throw new Error(`Unexpected version: ${version}`);
     }
-    if (version === "canary" || this.platform.arch === Arch.ARM64) {
+
+    const resolved = await this.versionResolver.resolve(version);
+    if (!resolved) {
       throw new Error(
-        `Chrome ${version} not supported for platform "${this.platform.os}" "${this.platform.arch}"`,
+        `Version ${version} not found in chrome for testing versions`,
       );
     }
 
-    const appguid = {
-      stable: "{8A69D345-D564-463C-AFF1-A69D9E530F96}",
-      beta: "{8237E44A-0054-442C-B6B6-EA0509993955}",
-      dev: "{401C381F-E0DE-4B85-8BD8-3F3F14FBDA57}",
-    };
-    const iid = "{980B7082-EC04-6DFB-63B8-08C1EC45EB8E}";
-    const lang = "en";
-    const browser = "3";
-    const usagestats = "0";
-    const appname = {
-      stable: "Google Chrome",
-      beta: "Google Chrome Beta",
-      dev: "Google Chrome Dev",
-    };
-    const needsadmin = "prefers";
-    const ap = {
-      [Arch.AMD64]: "-arch_x64-statsdef_1",
-      [Arch.I686]: "-arch_x86-statsdef_1",
-    };
-    const installdataindex = "empty";
-    const path = {
-      [Arch.AMD64]: {
-        stable: "chrome/install/ChromeStandaloneSetup64.exe",
-        beta: "chrome/install/beta/ChromeBetaStandaloneSetup64.exe",
-        dev: "chrome/install/dev/ChromeDevStandaloneSetup64.exe",
-      },
-      [Arch.I686]: {
-        stable: "chrome/install/ChromeStandaloneSetup.exe",
-        beta: "chrome/install/beta/ChromeBetaStandaloneSetup.exe",
-        dev: "chrome/install/dev/ChromeDevStandaloneSetup.exe",
-      },
-    };
-
-    const params = [
-      ["appguid", appguid[version]],
-      ["iid", iid],
-      ["lang", lang],
-      ["browser", browser],
-      ["usagestats", usagestats],
-      ["appname", encodeURIComponent(appname[version])],
-      ["needsadmin", needsadmin],
-      ["ap", ap[this.platform.arch]],
-      ["installdataindex", installdataindex],
-    ]
-      .map(([key, value]) => `${key}=${value}`)
-      .join("&");
-
-    const url = `https://dl.google.com/tag/s/${encodeURIComponent(params)}/${
-      path[this.platform.arch][version]
-    }`;
-
-    core.info(`Acquiring chrome ${version} from ${url}`);
-    const archivePath = await tc.downloadTool(url);
-
-    await fs.promises.rename(archivePath, `${archivePath}.exe`);
-    return { archive: `${archivePath}.exe` };
+    core.info(
+      `Acquiring chrome ${version} from ${resolved.browserDownloadURL}`,
+    );
+    const archive = await tc.downloadTool(resolved.browserDownloadURL);
+    return { archive };
   }
 
   async installBrowser(
@@ -123,22 +59,17 @@ export class WindowsChannelInstaller implements Installer {
     if (!isReleaseChannelName(version)) {
       throw new Error(`Unexpected version: ${version}`);
     }
-    await exec.exec(archive, ["/silent", "/install"]);
 
-    return { root: this.browserRootDir(version), bin: "chrome.exe" };
-  }
+    const extPath = await tc.extractZip(archive);
+    const extAppRoot = path.join(
+      extPath,
+      `chrome-${this.versionResolver.platformString}`,
+    );
 
-  private browserRootDir(version: ReleaseChannelName) {
-    switch (version) {
-      case "stable":
-        return "C:\\Program Files\\Google\\Chrome\\Application";
-      case "beta":
-        return "C:\\Program Files\\Google\\Chrome Beta\\Application";
-      case "dev":
-        return "C:\\Program Files\\Google\\Chrome Dev\\Application";
-      case "canary":
-        return "C:\\Program Files\\Google\\Chrome SxS\\Application";
-    }
+    const root = await cache.cacheDir(extAppRoot, "chromium", version);
+    core.info(`Successfully Installed chromium to ${root}`);
+
+    return { root, bin: "chrome.exe" };
   }
 
   async checkInstalledDriver(
@@ -154,7 +85,7 @@ export class WindowsChannelInstaller implements Installer {
     const resolved = await this.versionResolver.resolve(version);
     if (!resolved) {
       throw new Error(
-        `Version ${version} not found in the known good versions`,
+        `Version ${version} not found in chrome for testing versions`,
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ const testVersion = async (
 
 async function run(): Promise<void> {
   try {
-    const version = core.getInput("chrome-version") || "latest";
+    const version = core.getInput("chrome-version") || "stable";
     const platform = getPlatform();
     const flagInstallDependencies =
       core.getInput("install-dependencies") === "true";

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ async function run(): Promise<void> {
     core.addPath(path.dirname(browserBinPath));
     core.setOutput("chrome-path", browserBinPath);
     core.setOutput("chrome-version", actualBrowserVersion);
-    core.info(`Successfully setup chromium ${actualBrowserVersion}`);
+    core.info(`Successfully setup chrome ${actualBrowserVersion}`);
 
     if (flgInstallChromedriver) {
       core.info(`Setup chromedriver ${version}`);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,6 +1,6 @@
 export type InstallResult = {
-  root: string; // root is a directory containing all contents for chromium
-  bin: string; // bin is a sub-path to chromium executable binary from root
+  root: string; // root is a directory containing all contents for chrome
+  bin: string; // bin is a sub-path to chrome executable binary from root
 };
 
 export type DownloadResult = {

--- a/src/snapshot_installer.ts
+++ b/src/snapshot_installer.ts
@@ -12,7 +12,7 @@ export class SnapshotInstaller implements Installer {
   async checkInstalledBrowser(
     version: string,
   ): Promise<InstallResult | undefined> {
-    const root = await cache.find("chromium", version);
+    const root = await cache.find("chrome", version);
     if (root) {
       return { root, bin: "chrome" };
     }
@@ -51,8 +51,8 @@ export class SnapshotInstaller implements Installer {
       }
     })();
 
-    root = await cache.cacheDir(root, "chromium", version);
-    core.info(`Successfully Installed chromium to ${root}`);
+    root = await cache.cacheDir(root, "chrome", version);
+    core.info(`Successfully Installed chrome to ${root}`);
 
     return { root, bin };
   }

--- a/src/version_installer.ts
+++ b/src/version_installer.ts
@@ -34,7 +34,9 @@ export class KnownGoodVersionInstaller implements Installer {
       ? await this.versionResolver.resolveBrowserOnly(version)
       : await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
-      throw new Error(`Version ${version} not found in known good versions`);
+      throw new Error(
+        `Version ${version} not found in known good versions for ${this.platform.os} ${this.platform.arch}`,
+      );
     }
 
     core.info(
@@ -52,7 +54,9 @@ export class KnownGoodVersionInstaller implements Installer {
       ? await this.versionResolver.resolveBrowserOnly(version)
       : await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
-      throw new Error(`Version ${version} not found in known good versions`);
+      throw new Error(
+        `Version ${version} not found in known good versions for ${this.platform.os} ${this.platform.arch}`,
+      );
     }
     const extPath = await tc.extractZip(archive);
     const extAppRoot = path.join(
@@ -92,7 +96,9 @@ export class KnownGoodVersionInstaller implements Installer {
     const resolved =
       await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
-      throw new Error(`Version ${version} not found in known good versions`);
+      throw new Error(
+        `Version ${version} not found in known good versions for ${this.platform.os} ${this.platform.arch}`,
+      );
     }
 
     core.info(
@@ -113,7 +119,9 @@ export class KnownGoodVersionInstaller implements Installer {
     const resolved =
       await this.versionResolver.resolveBrowserAndDriver(version);
     if (!resolved) {
-      throw new Error(`Version ${version} not found in known good versions`);
+      throw new Error(
+        `Version ${version} not found in known good versions for ${this.platform.os} ${this.platform.arch}`,
+      );
     }
     const extPath = await tc.extractZip(archive);
     const extAppRoot = path.join(

--- a/src/version_installer.ts
+++ b/src/version_installer.ts
@@ -23,7 +23,7 @@ export class KnownGoodVersionInstaller implements Installer {
   async checkInstalledBrowser(
     version: string,
   ): Promise<InstallResult | undefined> {
-    const root = await cache.find("chromium", version);
+    const root = await cache.find("chrome", version);
     if (root) {
       return { root, bin: "chrome" };
     }
@@ -60,8 +60,8 @@ export class KnownGoodVersionInstaller implements Installer {
       `chrome-${this.versionResolver.platformString}`,
     );
 
-    const root = await cache.cacheDir(extAppRoot, "chromium", resolved.version);
-    core.info(`Successfully Installed chromium to ${root}`);
+    const root = await cache.cacheDir(extAppRoot, "chrome", resolved.version);
+    core.info(`Successfully Installed chrome to ${root}`);
     const bin = (() => {
       switch (this.platform.os) {
         case OS.DARWIN:


### PR DESCRIPTION
This PR introduces significant changes to improve stability and maintainability by switching to Chrome for Testing as the default browser.

### 1. Installer Changes on Channel Name Installs

This update replaces previous Chromium builds with the official Chrome for Testing browser on channel name installs. The installation process is simplified by using a standardized Chrome for Testing distribution. The action previously installed the browser to `C:\Program Files` using the official installer on Windows, or to `$RUNNER_TOOL_CACHE` on Linux and macOS with the official archive. Now, the action will install the browser to `$RUNNER_TOOL_CACHE` from [Chrome for Testing][].

[Chrome for Testing]: https://googlechromelabs.github.io/chrome-for-testing/

### 2. Cache Directory Changes

This update introduces a new cache directory structure for the Chrome for Testing browser. The cache directory is now named `chrome` instead of `chromium`.

### 3. Default Version Changes

Previously, the action installed the *latest* snapshot version. Now, the action will install the *stable* version of Chrome for Testing by default.

## Migration Guide

### 1. Installer Changes on Channel Name Installs

If you are using the channel name (`stable`, `beta`, `dev`, or `canary`) to install the browser, the new version of the action installs the browser from [Chrome for Testing][] instead of the official installer. Please check if your workflow is using the expected browser binary version with the new version of the action.

The installed browser binary with the channel name is as follows:

| Platform | New Binary Path |
|----------|----------------|
| Linux    | `chrome` |
| macOS    | `Google Chrome for Testing` |
| Windows  | `chrome.exe` |

On Windows runner, the installed location is changed from `C:\Program Files` to `$RUNNER_TOOL_CACHE`.

### 2. Cache Directory Changes

If you are self-hosted runner and installing the browser with the channel name to speed up the runner setup, please update your cache directory on your runners. The cache directory has been changed from `chromium` to `chrome` and ensure that your workflow is using the new cache directory.

### 3. Default Version Changes

If you don't specify `chrome-version` parameter in your workflow, please ensure that your workflow will install the expected version of Chrome for Testing. The default version is the *stable* channel version of Chrome for Testing instead of the *latest* version.  To install the *latest* version, you need to specify `chrome-version: latest` in your workflow.

```yaml
# v1
- name: Install the stable version of Chrome for Testing
  uses: browser-actions/setup-chrome@v1
  with:
    chrome-version: stable
- name: Install the latest version of Chrome for Testing
  uses: browser-actions/setup-chrome@v1

# v2
- name: Install the stable version of Chrome for Testing
  uses: browser-actions/setup-chrome@v2

- name: Install the latest version of Chrome for Testing
  uses: browser-actions/setup-chrome@v2
  with:
    chrome-version: latest
```