### PR TITLE
feat: Support snapshot installs on Windows ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,24 @@ jobs:
           (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chrome-path }}").Source).VersionInfo.ProductVersion
           (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chromedriver-path }}").Source).VersionInfo.ProductVersion
 
+  test-windows-arm:
+    needs: [build]
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+
+      - name: Install Google Chrome
+        uses: ./
+        with:
+          chrome-version: 1485971
+          install-chromedriver: true
+        id: setup-chrome
+      - run: |
+          (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chrome-path }}").Source).VersionInfo.ProductVersion
+          (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chromedriver-path }}").Source).VersionInfo.ProductVersion
+
   test-install-dependencies:
     needs: [build]
     strategy:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The action installs the stable version of Chrome for Testing by default.
 
 ```yaml
 steps:
-  - uses: browser-actions/setup-chrome@v1
+  - uses: browser-actions/setup-chrome@v2
   - run: chrome --version
 ```
 
@@ -26,7 +26,7 @@ To install a specific channel, use `chrome-version` input.
 
 ```yaml
 steps:
-  - uses: browser-actions/setup-chrome@v1
+  - uses: browser-actions/setup-chrome@v2
     with:
       chrome-version: 120
 ```
@@ -36,7 +36,7 @@ You can use the `install-chromedriver` to install the ChromeDriver.
 
 ```yaml
 steps:
-  - uses: browser-actions/setup-chrome@v1
+  - uses: browser-actions/setup-chrome@v2
     with:
       chrome-version: 120
       install-chromedriver: true
@@ -48,7 +48,7 @@ It installs the required dependencies for the Google Chrome/Chromium to run auto
 
 ```yaml
 steps:
-  - uses: browser-actions/setup-chrome@v1
+  - uses: browser-actions/setup-chrome@v2
     with:
       chrome-version: 120
       install-dependencies: true
@@ -74,7 +74,7 @@ To get the installed binary path, use `chrome-path` output of the action:
 
 ```yaml
 steps:
-  - uses: browser-actions/setup-chrome@v1
+  - uses: browser-actions/setup-chrome@v2
     id: setup-chrome
   - run: |
       ${{ steps.setup-chrome.outputs.chrome-path }} --version
@@ -101,6 +101,15 @@ steps:
 - `chromedriver-version`: The installed ChromeDriver version.
 
 [snapshots]: https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html
+
+## Supported platforms
+
+|                                      | Linux x64 | Mac x64 | Mac Arm64 | Windows | Windows Arm64 |
+| ---                                  | ---       | ---     | ---       | ---     | ---           |
+| Channel name (e.g. `stable`)         | ✅        | ✅      | ✅        | ✅      | ❌            |
+| Commit position (e.g. `1295939`)     | ✅        | ✅      | ✅        | ✅      | ✅            |
+| Specific version (e.g. `120.0.6099`) | ✅        | ✅      | ✅        | ✅      | ❌            |
+| Latest snapshot                      | ✅        | ✅      | ✅        | ✅      | ✅            |
 
 ## License
 

--- a/src/snapshot_bucket.ts
+++ b/src/snapshot_bucket.ts
@@ -47,14 +47,16 @@ const browserFileName = ({ os }: Platform): string => {
   }
 };
 
-const driverFileName = ({ os }: Platform): string => {
+const driverFileName = ({ os, arch }: Platform): string => {
   switch (os) {
     case OS.DARWIN:
       return "chromedriver_mac64.zip";
     case OS.LINUX:
       return "chromedriver_linux64.zip";
     case OS.WINDOWS:
-      return "chromedriver_win32.zip";
+      return arch === Arch.ARM64
+        ? "chromedriver_win64.zip"
+        : "chromedriver_win32.zip";
   }
 };
 
@@ -71,6 +73,8 @@ const makePlatformPart = ({ os, arch }: Platform): string => {
     return "Win";
   } else if (os === OS.WINDOWS && arch === Arch.AMD64) {
     return "Win_x64";
+  } else if (os === OS.WINDOWS && arch === Arch.ARM64) {
+    return "Win_Arm64";
   }
   throw new Error(`Unsupported platform "${os}" "${arch}"`);
 };

--- a/src/snapshot_installer.ts
+++ b/src/snapshot_installer.ts
@@ -3,7 +3,7 @@ import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
 import * as cache from "./cache";
 import type { DownloadResult, InstallResult, Installer } from "./installer";
-import { OS, type Platform } from "./platform";
+import { Arch, OS, type Platform } from "./platform";
 import { browserDownloadURL, driverDownloadURL } from "./snapshot_bucket";
 
 export class SnapshotInstaller implements Installer {
@@ -85,7 +85,9 @@ export class SnapshotInstaller implements Installer {
         case OS.LINUX:
           return path.join(extPath, "chromedriver_linux64");
         case OS.WINDOWS:
-          return path.join(extPath, "chromedriver_win32");
+          return this.platform.arch === Arch.ARM64
+            ? path.join(extPath, "chromedriver_win64")
+            : path.join(extPath, "chromedriver_win32");
       }
     })();
     const bin = (() => {


### PR DESCRIPTION
This PR adds support for installing Chrome and ChromeDriver from snapshots on Windows ARM64. It allows to install chrome browsers with snapshot numbers such as `1485971`.

```yaml
test-windows-arm:
  runs-on: windows-11-arm
  steps:
    - name: Install Google Chrome
      uses: browser-actions/setup-chrome@v2
      with:
        chrome-version: 1485971
        install-chromedriver: true
      id: setup-chrome
    - run: |
        (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chrome-path }}").Source).VersionInfo.ProductVersion
        (Get-Item (Get-Command "${{ steps.setup-chrome.outputs.chromedriver-path }}").Source).VersionInfo.ProductVersion
```