### PR TITLE
fix: drop 32-bit architecture support

### DIFF
--- a/src/chrome_for_testing.ts
+++ b/src/chrome_for_testing.ts
@@ -70,8 +70,6 @@ const platformString = (platform: Platform): PlatformString => {
     return "mac-arm64";
   } else if (platform.os === OS.WINDOWS && platform.arch === Arch.AMD64) {
     return "win64";
-  } else if (platform.os === OS.WINDOWS && platform.arch === Arch.I686) {
-    return "win32";
   }
   throw new Error(`Unsupported platform: ${platform.os} ${platform.arch}`);
 };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -16,7 +16,6 @@ export type OS = (typeof OS)[keyof typeof OS];
 
 export const Arch = {
   AMD64: "amd64",
-  I686: "i686",
   ARM64: "arm64",
 } as const;
 
@@ -39,8 +38,6 @@ export const getOS = (): OS => {
 export const getArch = (): Arch => {
   const arch = os.arch();
   switch (arch) {
-    case "x32":
-      return Arch.I686;
     case "x64":
       return Arch.AMD64;
     case "arm64":

--- a/src/snapshot_bucket.ts
+++ b/src/snapshot_bucket.ts
@@ -65,12 +65,8 @@ const makePlatformPart = ({ os, arch }: Platform): string => {
     return "Mac";
   } else if (os === OS.DARWIN && arch === Arch.ARM64) {
     return "Mac_Arm";
-  } else if (os === OS.LINUX && arch === Arch.I686) {
-    return "Linux";
   } else if (os === OS.LINUX && arch === Arch.AMD64) {
     return "Linux_x64";
-  } else if (os === OS.WINDOWS && arch === Arch.I686) {
-    return "Win";
   } else if (os === OS.WINDOWS && arch === Arch.AMD64) {
     return "Win_x64";
   } else if (os === OS.WINDOWS && arch === Arch.ARM64) {


### PR DESCRIPTION
Chrome is not distributed for Linux 32-bit ARM, which is the only GitHub Actions runner platform with a 32-bit architecture. The existing i686 code paths could therefore never be exercised in practice, making them dead code that gives false confidence 32-bit is a supported target.

This change removes all 32-bit (i686/x32) handling from the platform detection and the installer platform-string mappings. Unsupported architectures will now fail fast with a clear error.